### PR TITLE
Handle None value in raw_score check

### DIFF
--- a/t2av-compass/Subjective/eval_realism.py
+++ b/t2av-compass/Subjective/eval_realism.py
@@ -139,7 +139,7 @@ def compute_and_report_metrics(results_data):
             if criteria_dim not in buckets:
                 buckets[criteria_dim] = []
             raw_score = res.get('score', -1)
-            if raw_score == -1: 
+            if raw_score == -1 or raw_score is None: 
                 continue
             
             norm_score = (raw_score - 1) / 4.0


### PR DESCRIPTION
# Description 
There can be cases that not all `raw_score` are calculated, making the script crash. Thus the case of `None` value needs to be handled. 

# Crash message
```
...
...
============================================================
                     EVALUATION REPORT                      
============================================================
Traceback (most recent call last):
  File "/workspace/T2AV-Compass/t2av-compass/Subjective/eval_realism.py", line 310, in <module>
    main()
  File "/workspace/T2AV-Compass/t2av-compass/Subjective/eval_realism.py", line 305, in main
    compute_and_report_metrics(final_results)
  File "/workspace/T2AV-Compass/t2av-compass/Subjective/eval_realism.py", line 163, in compute_and_report_metrics
    norm_score = (raw_score - 1) / 4.0
                  ~~~~~~~~~~^~~
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

# Raw score values
```
...
...
2
5
3
3
5
None
...
...
```

# After the fix 
```
============================================================
Current Results Summary (before processing new tasks):
============================================================

============================================================
                     EVALUATION REPORT                      
============================================================

[1] Detailed Breakdown                                      
------------------------------------------------------------
    - AAS                : 0.4995
    - MSS                : 0.5045
    - MTC                : 0.4730
    - OIS                : 0.9235
    - TCS                : 0.4060
------------------------------------------------------------

[2] Video-Realism Calculation                               
Formula    : (MSS(0.5045) + OIS(0.9235) + TCS(0.4060)) / 3
Result     : 0.6113 -> 61.13/100

[3] Audio-Realism Calculation                               
Formula    : (AAS(0.4995) + MTC(0.4730)) / 2
Result     : 0.4862 -> 48.62/100
============================================================

Total tasks pending: 0
All tasks completed.
```

resolves   https://github.com/NJU-LINK/T2AV-Compass/issues/8