### PR TITLE
Fix DeSync calculation in Objective metrics

### DIFF
--- a/t2av-compass/Objective/Similarity/Synchformer-main/batch_test_folder.py
+++ b/t2av-compass/Objective/Similarity/Synchformer-main/batch_test_folder.py
@@ -220,7 +220,9 @@ def calculate_statistics(results: List[Dict[str, Any]]) -> Dict[str, Any]:
     # 提取偏移和概率
     offsets = [r['predicted_offset_sec'] for r in successful_results]
     probabilities = [r['predicted_probability'] for r in successful_results]
-    
+    abs_offsets = [abs(r['predicted_offset_sec']) for r in successful_results]
+    stats['abs_offsets'] = np.mean(abs_offsets)
+
     # 偏移量统计
     stats['predicted_offset_sec'] = {
         'mean': float(np.mean(offsets)),
@@ -311,7 +313,7 @@ def batch_test_folder(folder_path: str, exp_name: str, device: str = 'cuda:0',
             'folder_path': folder_path,
             'total_videos': 0,
             'results': [],
-            'statistics': {
+            'summary': {
                 'total_videos': 0,
                 'successful_videos': 0,
                 'failed_videos': 0
@@ -365,7 +367,7 @@ def batch_test_folder(folder_path: str, exp_name: str, device: str = 'cuda:0',
             'model_config': cfg_path,
             'model_checkpoint': ckpt_path
         },
-        'statistics': statistics,
+        'summary': statistics,
         'results': results
     }
     
@@ -405,14 +407,14 @@ def main():
     print(f"\n{'='*80}")
     print("统计摘要")
     print(f"{'='*80}")
-    print(f"总数: {output['statistics']['total_count']}")
-    print(f"成功: {output['statistics']['successful_count']}")
-    print(f"失败: {output['statistics']['failed_count']}")
+    print(f"总数: {output['summary']['total_count']}")
+    print(f"成功: {output['summary']['successful_count']}")
+    print(f"失败: {output['summary']['failed_count']}")
     
-    if output['statistics']['successful_count'] > 0 and 'predicted_offset_sec' in output['statistics']:
-        offset_stats = output['statistics']['predicted_offset_sec']
-        prob_stats = output['statistics']['predicted_probability']
-        
+    if output['summary']['successful_count'] > 0 and 'predicted_offset_sec' in output['summary']:
+        offset_stats = output['summary']['predicted_offset_sec']
+        prob_stats = output['summary']['predicted_probability']
+
         print(f"\n预测偏移量 (秒):")
         print(f"  平均值: {offset_stats['mean']:.6f}")
         print(f"  标准差: {offset_stats['std']:.6f}")
@@ -427,8 +429,8 @@ def main():
         print(f"  最大值: {prob_stats['max']:.6f}")
         print(f"  中位数: {prob_stats['median']:.6f}")
         
-        if 'sync_quality_distribution' in output['statistics']:
-            sync_dist = output['statistics']['sync_quality_distribution']
+        if 'sync_quality_distribution' in output['summary']:
+            sync_dist = output['summary']['sync_quality_distribution']
             print(f"\n同步质量分布:")
             print(f"  优秀 (≤0.1s): {sync_dist['excellent_<=0.1s']}")
             print(f"  良好 (0.1-0.2s): {sync_dist['good_0.1-0.2s']}")


### PR DESCRIPTION
# Description 

Fix `DeSync` score calculation and print it properly in `evaluation_summary.json`. 


Reference: https://github.com/hkchengrex/av-benchmark/blob/f351b9a6fc6abde746d5f8e1d4c47c883319cb41/av_bench/evaluate.py#L188

# Result 

## Before

```json
{
  "timestamp": "...",
  "input_dir": "/workspace/T2AV-Compass/input",
  "prompts_file": "/workspace/T2AV-Compass/t2av-compass/Data/prompts.json",
  "metrics": {
    "audio_aesthetic": {
      "..." 
    },
    "audio_video_alignment": {
      "mean_av_alignment": 0.2089688628911972,
      "total_samples": 1
    },
    "av_sync": {}, # Desync
    "lipsync": {
      "..."
    }, 
    "video_technical": {
      "..." 
    }
  }
}
```

## After 



```json
{
  "timestamp": "...",
  "input_dir": "/workspace/T2AV-Compass/input",
  "prompts_file": "/workspace/T2AV-Compass/t2av-compass/Data/prompts.json",
  "metrics": {
    "av_sync": {
      "timestamp": "...",
      "total_count": 500,
      "successful_count": 500,
      "failed_count": 0,
      "abs_offsets": 0.6940000037550926,  # Desync
      "predicted_offset_sec": {
        "mean": -0.38040000104904176,
        "std": 0.9203563655001262,
        "min": -2.0,
        "max": 2.0,
        "median": -0.20000000298023224
      },
      "predicted_probability": {
        "mean": 0.33302581787109375,
        "std": 0.29190504481731644,
        "min": 0.05450439453125,
        "max": 0.9921875,
        "median": 0.1995849609375
      },
      "offset_distribution": {
        "-1.6": 11,
        "0.0": 152,
        "-1.2": 25,
        "-2.0": 46,
        "-1.8": 29,
        "-0.2": 53,
        "2.0": 5,
        "-1.0": 18,
        "-0.6": 35,
        "1.2": 11,
        "0.6": 13,
        "-1.4": 6,
        "0.2": 11,
        "-0.4": 27,
        "1.8": 9,
        "0.4": 20,
        "0.8": 8,
        "-0.8": 10,
        "1.6": 4,
        "1.0": 4,
        "1.4": 3
      },
      "confidence_distribution": {
        "high_>=0.8": 60,
        "medium_0.5-0.8": 74,
        "low_<0.5": 366
      },
      "sync_quality_distribution": {
        "excellent_<=0.1s": 152,
        "good_0.1-0.2s": 0,
        "acceptable_0.2-0.5s": 111,
        "poor_>0.5s": 237
      }
    }
  }
}
```

resolves https://github.com/NJU-LINK/T2AV-Compass/issues/13